### PR TITLE
Silence deprecation warning

### DIFF
--- a/lib/apollo-federation/tracing.rb
+++ b/lib/apollo-federation/tracing.rb
@@ -9,11 +9,22 @@ module ApolloFederation
     module_function
 
     def use(schema)
-      schema.tracer ApolloFederation::Tracing::Tracer
+      if silence_deprecation_warning?
+        schema.tracer ApolloFederation::Tracing::Tracer, silence_deprecation_warning: true
+      else
+        schema.tracer ApolloFederation::Tracing::Tracer
+      end
     end
 
     def should_add_traces(headers)
       headers && headers[HEADER_NAME] == KEY.to_s
+    end
+
+    # Tracing is depreacted in graphql-ruby 2.0.0 and will be removed in 3.0.0
+    # https://github.com/rmosolgo/graphql-ruby/pull/4878/files#
+    def silence_deprecation_warning?
+      graphql_version = Gem.loaded_specs['graphql'].version
+      graphql_version >= Gem::Version.new('2') && graphql_version < Gem::Version.new('3')
     end
 
     # @deprecated There is no need to call this method. Traces are added to the result automatically

--- a/lib/apollo-federation/tracing.rb
+++ b/lib/apollo-federation/tracing.rb
@@ -23,8 +23,8 @@ module ApolloFederation
     # Tracing is depreacted in graphql-ruby 2.0.0 and will be removed in 3.0.0
     # https://github.com/rmosolgo/graphql-ruby/pull/4878/files#
     def silence_deprecation_warning?
-      graphql_version = Gem.loaded_specs['graphql'].version
-      graphql_version >= Gem::Version.new('2') && graphql_version < Gem::Version.new('3')
+      graphql_version = Gem::Version.new(GraphQL::VERSION)
+      graphql_version >= Gem::Version.new('2.3.0') && graphql_version < Gem::Version.new('3')
     end
 
     # @deprecated There is no need to call this method. Traces are added to the result automatically


### PR DESCRIPTION
https://github.com/Gusto/apollo-federation-ruby/issues/277

```
`Schema.tracer(ApolloFederation::Tracing::Tracer)` is deprecated; use module-based `trace_with` instead. See: https://graphql-ruby.org/queries/tracing.html
  /usr/local/bundle/gems/apollo-federation-3.8.5/lib/apollo-federation/tracing.rb:12:in `use'
```